### PR TITLE
BI 4.2: Fixed yaml rules on submarines to pass OpenRA Utility and RC linting

### DIFF
--- a/src/bi-balance-rules.yaml
+++ b/src/bi-balance-rules.yaml
@@ -257,9 +257,9 @@ SS:
 	AttackTurreted:
 	Turreted:
 		TurnSpeed: 512
-		LocalOffset: 0,-171,0, 0,171,0
 	-AttackFrontal:
-		FacingTolerance: 0
+	Armament:
+		LocalOffset: 0,-171,0, 0,171,0
 
 MSUB:
 	Buildable:


### PR DESCRIPTION
Fixed yaml rules to pass OpenRA Utility and resource center linting. No idea whether this preserves the intended effects

(Subs fire torpedos turreted. No idea what the Offset rule is supposed to do)